### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["zhongyi"]
 description = "An AppCtx implementation in Rust, like ApplicationContext in SpringBoot"
 readme = "README.md"
 license = "MIT"
+repository = "https://github.com/zhongyi51/app_ctx"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it